### PR TITLE
Bugfix: No longer crash when deleting all text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed crash when deleting all text
+
 ## [0.7.1] - 2021-06-28
 
 ### Changed

--- a/Sources/TextMarkupKit/ParsedAttributedString.swift
+++ b/Sources/TextMarkupKit/ParsedAttributedString.swift
@@ -178,7 +178,7 @@ private extension Logging.Logger {
       os_signpost(.end, log: log, name: "applyAttributes")
       applyReplacements(in: node, startingIndex: 0, to: _string)
     } else {
-      newAttributes = attributesArray
+      newAttributes.appendAttributes(defaultAttributes, length: _string.count)
     }
     // Deliver delegate messages
     Logger.attributedStringLogger.debug("Edit \(range) change in length \(_string.length - lengthBeforeChanges)")

--- a/Sources/TextMarkupKit/PieceTable.swift
+++ b/Sources/TextMarkupKit/PieceTable.swift
@@ -221,6 +221,7 @@ public struct PieceTable {
     }
   }
 
+  /// Discards all changes that have accumulated in this `PieceTable`. After this method completes, the piece table contains only `originalContents`.
   public mutating func revertToOriginal() {
     addedContents = NSMutableString()
     count = originalContents.length

--- a/Tests/TextMarkupKitTests/ParsedTextStorageTests.swift
+++ b/Tests/TextMarkupKitTests/ParsedTextStorageTests.swift
@@ -91,7 +91,7 @@ final class ParsedTextStorageTests: XCTestCase {
 //    XCTAssertEqual(textStorage.storage.rawString, "# This is a heading\n\nAnd this is a paragraph")
 //  }
 
-  /// This used to crash because I was inproperly managing the blank_line nodes when coalescing them. It showed up when
+  /// This used to crash because I was inproperly managing the `blank_line` nodes when coalescing them. It showed up when
   /// re-using memoized results.
   func testReproduceTypingBug() {
     let initialString = "# Welcome to Scrap Paper.\n\n\n\n##\n\n"
@@ -113,6 +113,14 @@ final class ParsedTextStorageTests: XCTestCase {
     textStorage.replaceCharacters(in: NSRange(location: 5, length: 0), with: "x")
     // We should now have one more character than we did previously
     XCTAssertEqual(textStorage.string.count, 13)
+  }
+
+  func testDeleteEverything() {
+    let initialString = "Test ![](image.png) image"
+    textStorage.append(NSAttributedString(string: initialString))
+    XCTAssertEqual(textStorage.string.count, 12)
+    textStorage.replaceCharacters(in: NSRange(location: 0, length: textStorage.string.utf16.count), with: "")
+    XCTAssertEqual(textStorage.string.count, 0)
   }
 
   #if !os(macOS)


### PR DESCRIPTION
Apparently, in the mini-markdown grammar, the empty string doesn't parse. This exposed a bug in the code path of computing updated attributes when the new text didn't parse. My code said, "If the text doesn't parse, the attributes array _is unchanged_" -- this is wrong, because the *text* changes, and the old attributes array won't match the length of the new text.

The fixed code says, "If the text doesn't parse, _the entire text now has default attributes._"